### PR TITLE
Fix template selection sync and add local storage tests

### DIFF
--- a/docs/review_tasks.md
+++ b/docs/review_tasks.md
@@ -1,0 +1,21 @@
+# Follow-up Quality Tasks
+
+## Recently Completed
+- ✅ Corrected the "Rubika Learning Tools" branding across metadata sources.
+- ✅ Ensured the prompt template selector stays in sync with saved prompts.
+- ✅ Aligned the dark-mode comment with the inline theme script.
+- ✅ Added regression coverage for local-storage synchronization helpers.
+
+## Next Ideas to Consider
+1. **Improve library UX for long prompt titles**
+   - Truncate or wrap long titles inside the Biblioteca drawer to avoid layout shifts on small screens.
+   - Files: `src/pages/PrompterPage.tsx` (list markup and styles).
+2. **Persist anti-sesgo toggle across sessions**
+   - Mirror the existing `useLocalStorage` pattern used for templates so the anti-bias flag survives reloads.
+   - Files: `src/pages/PrompterPage.tsx` (state management).
+3. **Add integration coverage for prompt generation**
+   - Create a high-level test that saves a prompt and reloads it to ensure the full flow works with the new synchronization helpers.
+   - Files: consider a lightweight Node-based test harness under `hooks/__tests__` or a future UI test runner.
+4. **Document the custom test workflow**
+   - Expand the README with instructions for running the new TypeScript-to-Node test pipeline so contributors know why `npm test` now compiles to `dist-tests`.
+   - Files: `README.md` (testing section).

--- a/hooks/__tests__/useLocalStorage.test.ts
+++ b/hooks/__tests__/useLocalStorage.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getStoredValue, syncFromStorageEvent } from '../useLocalStorage.js';
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+test('getStoredValue returns persisted data when available', () => {
+  const storage = new MemoryStorage();
+  storage.setItem('example', JSON.stringify({ greeting: 'hola' }));
+
+  const value = getStoredValue(storage, 'example', { greeting: 'adiós' });
+
+  assert.deepEqual(value, { greeting: 'hola' });
+});
+
+test('getStoredValue falls back to initial value on parse errors', () => {
+  const storage = new MemoryStorage();
+  storage.setItem('broken', 'not-json');
+
+  const originalError = console.error;
+  let logged = false;
+  console.error = () => {
+    logged = true;
+  };
+
+  const value = getStoredValue(storage, 'broken', { ok: true });
+
+  console.error = originalError;
+
+  assert.deepEqual(value, { ok: true });
+  assert.equal(logged, true);
+});
+
+test('syncFromStorageEvent updates the value when keys match', () => {
+  let nextValue: unknown = null;
+
+  syncFromStorageEvent(
+    { key: 'shared', newValue: JSON.stringify(['remote']) },
+    'shared',
+    [],
+    (value) => {
+      nextValue = value;
+    },
+  );
+
+  assert.deepEqual(nextValue, ['remote']);
+});
+
+test('syncFromStorageEvent restores initial value on null payload', () => {
+  let nextValue: unknown = null;
+
+  syncFromStorageEvent(
+    { key: 'shared', newValue: null },
+    'shared',
+    ['initial'],
+    (value) => {
+      nextValue = value;
+    },
+  );
+
+  assert.deepEqual(nextValue, ['initial']);
+});
+
+test('syncFromStorageEvent ignores unrelated keys', () => {
+  let called = false;
+
+  syncFromStorageEvent(
+    { key: 'other', newValue: JSON.stringify('value') },
+    'shared',
+    'initial',
+    () => {
+      called = true;
+    },
+  );
+
+  assert.equal(called, false);
+});

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -1,19 +1,42 @@
 
 import { useState, useEffect } from 'react';
 
+export function getStoredValue<T>(storage: Storage | undefined, key: string, initialValue: T): T {
+  if (!storage) {
+    return initialValue;
+  }
+
+  try {
+    const item = storage.getItem(key);
+    return item ? JSON.parse(item) : initialValue;
+  } catch (error) {
+    console.error(error);
+    return initialValue;
+  }
+}
+
+export function syncFromStorageEvent<T>(
+  event: Pick<StorageEvent, 'key' | 'newValue'>,
+  key: string,
+  initialValue: T,
+  updateValue: (value: T) => void,
+): void {
+  if (event.key !== key) {
+    return;
+  }
+
+  try {
+    const parsedValue = event.newValue ? JSON.parse(event.newValue) : initialValue;
+    updateValue(parsedValue);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
 function useLocalStorage<T,>(key: string, initialValue: T): [T, (value: T) => void] {
-  const [storedValue, setStoredValue] = useState<T>(() => {
-    if (typeof window === 'undefined') {
-      return initialValue;
-    }
-    try {
-      const item = window.localStorage.getItem(key);
-      return item ? JSON.parse(item) : initialValue;
-    } catch (error) {
-      console.error(error);
-      return initialValue;
-    }
-  });
+  const [storedValue, setStoredValue] = useState<T>(() =>
+    getStoredValue(typeof window === 'undefined' ? undefined : window.localStorage, key, initialValue),
+  );
 
   const setValue = (value: T) => {
     try {
@@ -26,22 +49,21 @@ function useLocalStorage<T,>(key: string, initialValue: T): [T, (value: T) => vo
       console.error(error);
     }
   };
-  
+
   useEffect(() => {
-    const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === key) {
-        try {
-          setStoredValue(e.newValue ? JSON.parse(e.newValue) : initialValue);
-        } catch (error) {
-          console.error(error);
-        }
-      }
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleStorageChange = (event: StorageEvent) => {
+      syncFromStorageEvent(event, key, initialValue, setStoredValue);
     };
+
     window.addEventListener('storage', handleStorageChange);
     return () => {
       window.removeEventListener('storage', handleStorageChange);
     };
-     // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key, initialValue]);
 
 

--- a/index.html
+++ b/index.html
@@ -5,20 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- SEO Meta Tags -->
-    <title>Prompt Architect — Rubika Learnings Tools</title>
+    <title>Prompt Architect — Rubika Learning Tools</title>
     <meta name="description" content="Set de prompts listos para vender, validar y escalar tu emprendimiento. No alcanza solo con pagar IA; hay que saber usarla también.">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://rubika.com/">
-    <meta property="og:title" content="Prompt Architect — Rubika Learnings Tools">
+    <meta property="og:title" content="Prompt Architect — Rubika Learning Tools">
     <meta property="og:description" content="Set de prompts listos para vender, validar y escalar tu emprendimiento. No alcanza solo con pagar IA; hay que saber usarla también.">
     <meta property="og:image" content="https://i.imgur.com/Vq1zZ2H.png">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://rubika.com/">
-    <meta property="twitter:title" content="Prompt Architect — Rubika Learnings Tools">
+    <meta property="twitter:title" content="Prompt Architect — Rubika Learning Tools">
     <meta property="twitter:description" content="Set de prompts listos para vender, validar y escalar tu emprendimiento. No alcanza solo con pagar IA; hay que saber usarla también.">
     <meta property="twitter:image" content="https://i.imgur.com/Vq1zZ2H.png">
 
@@ -45,7 +45,7 @@
       "description": "Set de prompts listos para vender, validar y escalar tu emprendimiento. No alcanza solo con pagar IA; hay que saber usarla también.",
       "brand": {
         "@type": "Brand",
-        "name": "Rubika Learnings Tools"
+        "name": "Rubika Learning Tools"
       },
       "aggregateRating": {
         "@type": "AggregateRating",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "pretest": "tsc --project tsconfig.test.json",
+    "test": "node --test dist-tests/hooks/__tests__/useLocalStorage.test.js"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.13",

--- a/src/constants/landing.ts
+++ b/src/constants/landing.ts
@@ -24,7 +24,7 @@
 
 // SEO & METADATA
 export const META_DATA = {
-  title: "Prompt Architect — Rubika Learnings Tools",
+  title: "Prompt Architect — Rubika Learning Tools",
   description: "Set de prompts listos para vender, validar y escalar tu emprendimiento. No alcanza solo con pagar IA; hay que saber usarla también.",
   ogImage: "https://example.com/og-image-rubika.jpg" // Placeholder OG image
 };

--- a/src/pages/PrompterPage.tsx
+++ b/src/pages/PrompterPage.tsx
@@ -8,12 +8,22 @@ import useLocalStorage from '@/hooks/useLocalStorage';
 interface IdeaObjetivoCardProps {
     activeTab: 'normal' | 'programmer';
     setActiveTab: (tab: 'normal' | 'programmer') => void;
+    selectedTemplate: PromptTemplate | null;
     setSelectedTemplate: (template: PromptTemplate | null) => void;
     setVariableValues: (values: Record<string, any>) => void;
 }
-const IdeaObjetivoCard: React.FC<IdeaObjetivoCardProps> = ({ activeTab, setActiveTab, setSelectedTemplate, setVariableValues }) => {
+const IdeaObjetivoCard: React.FC<IdeaObjetivoCardProps> = ({
+    activeTab,
+    setActiveTab,
+    selectedTemplate,
+    setSelectedTemplate,
+    setVariableValues,
+}) => {
     const normalTemplates = useMemo(() => PROMPT_TEMPLATES.filter(p => p.category === 'normal'), []);
     const programmerTemplates = useMemo(() => PROMPT_TEMPLATES.filter(p => p.category === 'programmer'), []);
+
+    const selectedProgrammerTemplateId = selectedTemplate?.category === 'programmer' ? selectedTemplate.id : '';
+    const selectedNormalTemplateId = selectedTemplate?.category === 'normal' ? selectedTemplate.id : '';
 
     const handleSelectChange = (id: string) => {
          const newTemplate = PROMPT_TEMPLATES.find(t => t.id === id);
@@ -61,9 +71,9 @@ const IdeaObjetivoCard: React.FC<IdeaObjetivoCardProps> = ({ activeTab, setActiv
                 {activeTab === 'programmer' && (
                     <div>
                         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Seleccioná un prompt de programación</label>
-                         <select
+                        <select
                             onChange={(e) => handleSelectChange(e.target.value)}
-                            defaultValue=""
+                            value={selectedProgrammerTemplateId}
                             className="w-full p-2 border border-gray-300 rounded-md bg-white dark:bg-slate-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500"
                         >
                             <option value="" disabled>Elegí una plantilla...</option>
@@ -77,9 +87,9 @@ const IdeaObjetivoCard: React.FC<IdeaObjetivoCardProps> = ({ activeTab, setActiv
                     <div>
                         {/* This can be expanded later with the idea -> suggestion flow */}
                         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Seleccioná una plantilla</label>
-                         <select
+                        <select
                             onChange={(e) => handleSelectChange(e.target.value)}
-                            defaultValue=""
+                            value={selectedNormalTemplateId}
                             className="w-full p-2 border border-gray-300 rounded-md bg-white dark:bg-slate-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500"
                         >
                             <option value="" disabled>Elegí una plantilla...</option>
@@ -265,7 +275,7 @@ const App: React.FC = () => {
     } else {
       root.classList.remove('dark');
     }
-    // No FOUC script in index.html is needed anymore with this setup
+    // Mantiene sincronizado el valor con el script inline en index.html que previene FOUC
     localStorage.setItem('theme', isProgrammerMode ? 'dark' : 'light');
   }, [isProgrammerMode]);
 
@@ -359,6 +369,7 @@ const App: React.FC = () => {
                 <IdeaObjetivoCard
                     activeTab={activeTab}
                     setActiveTab={setActiveTab}
+                    selectedTemplate={selectedTemplate}
                     setSelectedTemplate={setSelectedTemplate}
                     setVariableValues={setVariableValues}
                 />

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist-tests",
+    "rootDir": ".",
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "types": ["node"]
+  },
+  "include": [
+    "hooks/useLocalStorage.ts",
+    "hooks/__tests__/useLocalStorage.test.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- update landing metadata and marketing constants to use the corrected "Rubika Learning Tools" branding
- make the template selectors controlled so saved prompts rehydrate the correct option and document the dark-mode sync comment
- expose helpers for local-storage synchronization, cover them with node-based tests, and record the workflow in the review tasks doc

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de7e70d970832cb1c42100367dc2e8